### PR TITLE
Update to latest CoffeeNet parent version 0.26.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>coffee.synyx</groupId>
         <artifactId>coffeenet-starter-parent</artifactId>
-        <version>0.25.0</version>
+        <version>0.26.0</version>
         <relativePath/>
     </parent>
 


### PR DESCRIPTION
New CoffeeNet parent version 0.26.0 was released! Please check https://github.com/coffeenet/coffeenet-starter/blob/master/CHANGELOG.md for more information